### PR TITLE
Unify visual grammar across writing and projects sections

### DIFF
--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from "react";
+
+const accentText: Record<string, string> = {
+  sky: "text-sky",
+  green: "text-green",
+  yellow: "text-yellow",
+  pink: "text-pink",
+  orange: "text-orange",
+};
+
+type PageHeroProps = {
+  eyebrow: string;
+  title: string;
+  accent?: keyof typeof accentText;
+  description?: string;
+  size?: "lg" | "md";
+  children?: ReactNode;
+};
+
+export const PageHero = ({ eyebrow, title, accent = "pink", description, size = "lg", children }: PageHeroProps) => (
+  <>
+    <p className="text-sm uppercase tracking-widest text-foreground/60 mb-4">{eyebrow}</p>
+    <h1 className={`wordmark ${size === "lg" ? "text-6xl md:text-8xl" : "text-5xl md:text-7xl"} mb-4`}>
+      {title}
+      <span className={accentText[accent]}>.</span>
+    </h1>
+    {description && <p className="max-w-2xl text-lg text-foreground/70">{description}</p>}
+    {children}
+  </>
+);

--- a/src/components/PostListItem.tsx
+++ b/src/components/PostListItem.tsx
@@ -1,0 +1,53 @@
+import { Link } from "react-router-dom";
+import type { Post } from "@/lib/craft";
+
+const dotColors = ["bg-sky", "bg-green", "bg-yellow", "bg-pink", "bg-orange"];
+
+const formatDate = (d: string) =>
+  new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+
+type PostListItemProps = {
+  post: Post;
+  activeTag?: string;
+};
+
+export const PostListItem = ({ post, activeTag }: PostListItemProps) => (
+  <li>
+    <Link
+      to={`/writing/${post.slug}`}
+      className="group grid grid-cols-12 gap-6 py-8 items-baseline hover:bg-secondary/40 -mx-4 px-4 rounded-lg transition-colors"
+    >
+      <div className="col-span-12 md:col-span-3 text-sm text-muted-foreground tabular-nums">
+        {post.date && formatDate(post.date)}
+        <div className="text-xs text-muted-foreground/70 mt-1">{post.readingTime} min read</div>
+      </div>
+      <div className="col-span-12 md:col-span-9">
+        <h3 className="text-2xl md:text-3xl font-light tracking-tight group-hover:text-foreground/70 transition-colors">
+          {post.title}
+        </h3>
+        {post.excerpt && (
+          <p className="mt-3 text-foreground/65 leading-relaxed line-clamp-2">{post.excerpt}</p>
+        )}
+        {post.tags.length > 0 && (
+          <div className="mt-4 flex flex-wrap gap-3">
+            {post.tags.slice(0, 4).map((t, i) => (
+              <Link
+                key={t}
+                to={`/writing/tag/${encodeURIComponent(t)}`}
+                onClick={(e) => e.stopPropagation()}
+                className={`inline-flex items-center gap-1.5 text-xs hover:text-foreground transition-colors ${
+                  activeTag && t.toLowerCase() === activeTag.toLowerCase()
+                    ? "text-foreground"
+                    : "text-foreground/55"
+                }`}
+              >
+                <span className={`h-1.5 w-1.5 rounded-full ${dotColors[i % 5]}`} />
+                {t}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </Link>
+  </li>
+);

--- a/src/pages/Archive.tsx
+++ b/src/pages/Archive.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import { SiteLayout } from "@/components/SiteLayout";
+import { PageHero } from "@/components/PageHero";
 import { fetchPosts } from "@/lib/craft";
 import { Input } from "@/components/ui/input";
 
@@ -40,13 +41,10 @@ const Archive = () => {
 
   return (
     <SiteLayout>
-      <section className="container py-16 md:py-24 max-w-4xl">
+      <section className="container py-16 md:py-24">
         <div className="flex items-baseline justify-between gap-4 flex-wrap">
           <div>
-            <p className="text-sm uppercase tracking-widest text-foreground/60 mb-3">Archive</p>
-            <h1 className="wordmark text-5xl md:text-7xl">
-              Everything written<span className="text-sky">.</span>
-            </h1>
+            <PageHero eyebrow="Archive" title="Everything written" accent="sky" size="md" />
           </div>
           <Link to="/writing/search" className="text-sm text-foreground/65 hover:text-foreground underline underline-offset-4">
             Full-text search →

--- a/src/pages/Experience.tsx
+++ b/src/pages/Experience.tsx
@@ -1,4 +1,5 @@
 import { SiteLayout } from "@/components/SiteLayout";
+import { PageHero } from "@/components/PageHero";
 import { experiences } from "@/content/experience";
 import { education } from "@/content/education";
 import { skillCategories } from "@/content/skills";
@@ -22,13 +23,12 @@ const Experience = () => {
     <SiteLayout>
       {/* Header */}
       <section className="container py-16 md:py-24">
-        <p className="text-sm uppercase tracking-widest text-foreground/60 mb-4">Career</p>
-        <h1 className="wordmark text-6xl md:text-8xl mb-4">
-          Work experience<span className="text-pink">.</span>
-        </h1>
-        <p className="max-w-2xl text-lg text-foreground/70">
-          A timeline of roles, projects, and growth across design, engineering, and leadership.
-        </p>
+        <PageHero
+          eyebrow="Career"
+          title="Work experience"
+          accent="pink"
+          description="A timeline of roles, projects, and growth across design, engineering, and leadership."
+        />
       </section>
 
       {/* Experience Section */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { SiteLayout } from "@/components/SiteLayout";
 import { HeroBlobField } from "@/components/Blob";
+import { PostListItem } from "@/components/PostListItem";
 import { fetchPosts, fetchProjects } from "@/lib/craft";
 import { ArrowUpRight } from "lucide-react";
 
@@ -12,9 +13,6 @@ const accentDot: Record<string, string> = {
   pink: "bg-pink",
   orange: "bg-orange",
 };
-
-const formatDate = (d: string) =>
-  new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 
 const Index = () => {
   const { data: allPosts } = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
@@ -76,27 +74,7 @@ const Index = () => {
             <li className="py-8 text-muted-foreground">No published posts yet.</li>
           )}
           {posts.map((p) => (
-            <li key={p.id}>
-              <Link to={`/writing/${p.slug}`} className="group grid grid-cols-12 gap-4 py-6 items-baseline">
-                <div className="col-span-12 md:col-span-3 text-sm text-muted-foreground tabular-nums">
-                  {p.date && formatDate(p.date)} · {p.readingTime} min
-                </div>
-                <div className="col-span-12 md:col-span-9">
-                  <h3 className="text-2xl md:text-3xl font-light tracking-tight group-hover:text-foreground transition-colors">
-                    {p.title}
-                  </h3>
-                  {p.excerpt && <p className="mt-2 text-foreground/70 line-clamp-2">{p.excerpt}</p>}
-                  <div className="mt-3 flex gap-2">
-                    {p.tags.slice(0, 3).map((t, i) => (
-                      <span key={t} className="inline-flex items-center gap-1.5 text-xs text-foreground/60">
-                        <span className={`h-1.5 w-1.5 rounded-full ${["bg-sky","bg-green","bg-yellow","bg-pink","bg-orange"][i % 5]}`} />
-                        {t}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </Link>
-            </li>
+            <PostListItem key={p.id} post={p} />
           ))}
         </ul>
       </section>

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -61,12 +61,12 @@ const Post = () => {
       <article className="container py-16 md:py-24 max-w-3xl">
         <Link
           to="/writing"
-          className="inline-flex items-center gap-2 text-sm text-foreground/65 hover:text-foreground transition-colors mb-12"
+          className="inline-flex items-center gap-2 text-sm text-foreground/65 hover:text-foreground transition-colors mb-10"
         >
           <ArrowLeft className="h-4 w-4" /> All writing
         </Link>
 
-        <header className="mb-12">
+        <header className="mb-10">
           <div className="text-sm text-muted-foreground mb-4 tabular-nums">
             {post.date && formatDate(post.date)} · {post.readingTime} min read
           </div>

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -65,7 +65,7 @@ const Project = () => {
             <span className={`h-2 w-2 rounded-full ${accentDot[project.accent]}`} />
             {project.year} · {project.role}
           </div>
-          <h1 className="wordmark text-5xl md:text-6xl mb-4">{project.title}</h1>
+          <h1 className="wordmark text-4xl md:text-6xl mb-4 leading-[1.05]">{project.title}</h1>
           <p className="text-xl text-foreground/70">{project.summary}</p>
           <div className="mt-6 flex flex-wrap gap-2">
             {project.stack.map((s) => (

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { SiteLayout } from "@/components/SiteLayout";
+import { PageHero } from "@/components/PageHero";
 import { fetchProjects } from "@/lib/craft";
 
 const accentDot: Record<string, string> = {
@@ -17,13 +18,12 @@ const Projects = () => {
   return (
     <SiteLayout>
       <section className="container py-16 md:py-24">
-        <p className="text-sm uppercase tracking-widest text-foreground/60 mb-4">Projects</p>
-        <h1 className="wordmark text-6xl md:text-8xl mb-4">
-          Things I've built<span className="text-green">.</span>
-        </h1>
-        <p className="max-w-2xl text-lg text-foreground/70">
-          Selected work across systems design, infrastructure, and platform engineering.
-        </p>
+        <PageHero
+          eyebrow="Projects"
+          title="Things I've built"
+          accent="green"
+          description="Selected work across systems design, infrastructure, and platform engineering."
+        />
 
         {isLoading && <p className="mt-16 text-muted-foreground">Loading projects...</p>}
         {error && <p className="mt-16 text-destructive">Couldn't load projects. Try again shortly.</p>}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -56,7 +56,7 @@ const SearchPage = () => {
 
   return (
     <SiteLayout>
-      <section className="container py-16 md:py-24 max-w-4xl">
+      <section className="container py-16 md:py-24">
         <Link to="/writing" className="inline-flex items-center gap-2 text-sm text-foreground/65 hover:text-foreground mb-10">
           <ArrowLeft className="h-4 w-4" /> All writing
         </Link>

--- a/src/pages/Tag.tsx
+++ b/src/pages/Tag.tsx
@@ -2,13 +2,9 @@ import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { SiteLayout } from "@/components/SiteLayout";
+import { PostListItem } from "@/components/PostListItem";
 import { fetchPosts } from "@/lib/craft";
 import { PostListSkeleton } from "@/components/PostListSkeleton";
-
-const formatDate = (d: string) =>
-  new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
-
-const dotColors = ["bg-sky", "bg-green", "bg-yellow", "bg-pink", "bg-orange"];
 
 const Tag = () => {
   const { tag } = useParams<{ tag: string }>();
@@ -19,7 +15,7 @@ const Tag = () => {
 
   return (
     <SiteLayout>
-      <section className="container py-16 md:py-24 max-w-4xl">
+      <section className="container py-16 md:py-24">
         <Link to="/writing" className="inline-flex items-center gap-2 text-sm text-foreground/65 hover:text-foreground mb-10">
           <ArrowLeft className="h-4 w-4" /> All writing
         </Link>
@@ -46,35 +42,7 @@ const Tag = () => {
 
           <ul className="divide-y divide-border">
             {filtered.map((p) => (
-              <li key={p.id}>
-                <Link to={`/writing/${p.slug}`} className="group grid grid-cols-12 gap-6 py-8 items-baseline">
-                  <div className="col-span-12 md:col-span-3 text-sm text-muted-foreground tabular-nums">
-                    {p.date && formatDate(p.date)}
-                    <div className="text-xs text-muted-foreground/70 mt-1">{p.readingTime} min read</div>
-                  </div>
-                  <div className="col-span-12 md:col-span-9">
-                    <h3 className="text-2xl md:text-3xl font-light tracking-tight group-hover:text-foreground/70 transition-colors">
-                      {p.title}
-                    </h3>
-                    {p.excerpt && <p className="mt-3 text-foreground/65 leading-relaxed line-clamp-2">{p.excerpt}</p>}
-                    {p.tags.length > 0 && (
-                      <div className="mt-4 flex flex-wrap gap-3">
-                        {p.tags.slice(0, 4).map((t, i) => (
-                          <span
-                            key={t}
-                            className={`inline-flex items-center gap-1.5 text-xs ${
-                              t.toLowerCase() === decoded.toLowerCase() ? "text-foreground" : "text-foreground/55"
-                            }`}
-                          >
-                            <span className={`h-1.5 w-1.5 rounded-full ${dotColors[i % 5]}`} />
-                            {t}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </Link>
-              </li>
+              <PostListItem key={p.id} post={p} activeTag={decoded} />
             ))}
           </ul>
         </div>

--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -2,13 +2,10 @@ import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Search } from "lucide-react";
 import { SiteLayout } from "@/components/SiteLayout";
+import { PageHero } from "@/components/PageHero";
+import { PostListItem } from "@/components/PostListItem";
 import { fetchPosts } from "@/lib/craft";
 import { PostListSkeleton } from "@/components/PostListSkeleton";
-
-const formatDate = (d: string) =>
-  new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
-
-const dotColors = ["bg-sky", "bg-green", "bg-yellow", "bg-pink", "bg-orange"];
 
 const Writing = () => {
   const { data: posts, isLoading, error } = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
@@ -16,14 +13,13 @@ const Writing = () => {
 
   return (
     <SiteLayout>
-      <section className="container py-16 md:py-24 max-w-4xl">
-        <p className="text-sm uppercase tracking-widest text-foreground/60 mb-4">Writing</p>
-        <h1 className="wordmark text-6xl md:text-8xl mb-6">
-          Notes &amp; essays<span className="text-pink">.</span>
-        </h1>
-        <p className="max-w-2xl text-lg text-foreground/70">
-          Working notes on systems design, infrastructure, and the craft of being a solutions architect.
-        </p>
+      <section className="container py-16 md:py-24">
+        <PageHero
+          eyebrow="Writing"
+          title="Notes & essays"
+          accent="pink"
+          description="Working notes on systems design, infrastructure, and the craft of being a solutions architect."
+        />
 
         <div className="mt-8 flex flex-wrap items-center gap-3">
           <Link
@@ -54,37 +50,7 @@ const Writing = () => {
 
           <ul className="divide-y divide-border">
             {recent.map((p) => (
-              <li key={p.id}>
-                <Link to={`/writing/${p.slug}`} className="group grid grid-cols-12 gap-6 py-8 items-baseline">
-                  <div className="col-span-12 md:col-span-3 text-sm text-muted-foreground tabular-nums">
-                    {p.date && formatDate(p.date)}
-                    <div className="text-xs text-muted-foreground/70 mt-1">{p.readingTime} min read</div>
-                  </div>
-                  <div className="col-span-12 md:col-span-9">
-                    <h3 className="text-2xl md:text-3xl font-light tracking-tight group-hover:text-foreground/70 transition-colors">
-                      {p.title}
-                    </h3>
-                    {p.excerpt && (
-                      <p className="mt-3 text-foreground/65 leading-relaxed line-clamp-2">{p.excerpt}</p>
-                    )}
-                    {p.tags.length > 0 && (
-                      <div className="mt-4 flex flex-wrap gap-3">
-                        {p.tags.slice(0, 4).map((t, i) => (
-                          <Link
-                            key={t}
-                            to={`/writing/tag/${encodeURIComponent(t)}`}
-                            onClick={(e) => e.stopPropagation()}
-                            className="inline-flex items-center gap-1.5 text-xs text-foreground/55 hover:text-foreground transition-colors"
-                          >
-                            <span className={`h-1.5 w-1.5 rounded-full ${dotColors[i % 5]}`} />
-                            {t}
-                          </Link>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </Link>
-              </li>
+              <PostListItem key={p.id} post={p} />
             ))}
           </ul>
 


### PR DESCRIPTION
## Summary

Navigating between `/writing` and `/projects` (and their sub-pages) felt visually inconsistent — different content widths, heading scales, and hover behavior. Investigation showed most of the divergence was accidental drift from copy-pasted markup, not deliberate design. This PR unifies the structural grammar while keeping the intentional idiom contrast: editorial lists for writing, accent-blob cards for projects (as the home page already does side by side).

### New shared components

- **`PageHero`** — the eyebrow + wordmark title + accent period + description header, with `lg`/`md` size tiers. Adopted by Writing, Projects, Experience, and Archive, so section heroes are now identical in scale and spacing across routes.
- **`PostListItem`** — the post row previously copy-pasted with drift across `Index`, `Writing`, and `Tag`. Unification also brings two upgrades everywhere: the row hover-surface treatment only Archive had (`hover:bg-secondary/40`, the list-world sibling of the project cards' hover), and tags rendered as links (home and tag pages previously rendered dead spans).

### Width and scale alignment

- Writing index pages (`/writing`, archive, search, tag) drop their `max-w-4xl` constraint and use the full container width, matching the home page's writing section and the projects grid.
- Article detail pages (`Post`, `Project`) keep the slim `max-w-3xl` reading measure — narrowing for long-form content is now a consistent pattern across both sections rather than a per-section quirk.
- `Project` title scale aligned to `Post` (`text-4xl md:text-6xl`); back-link and header margins matched so the header block doesn't shift between article types.

Net: ~90 lines of duplicated JSX removed; future row/hero changes happen in one place.

## Verification

- `npx tsc --noEmit` passes; `npm run build` passes (RSS generation intact)
- Production build served locally: `/`, `/writing`, `/writing/archive`, `/projects`, `/experience` all return 200
- Lint findings are pre-existing (shadcn scaffolding, config) — none in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)