### PR TITLE
Fix external Craft links + rebrand to AI Solutions Engineer

### DIFF
--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -163,7 +163,7 @@ function buildFeed(posts) {
   <channel>
     <title>aycarl — Writing</title>
     <link>${SITE_URL}/writing</link>
-    <description>Notes and essays on systems design, infrastructure, and the craft of being a solutions architect.</description>
+    <description>Notes on building useful things with AI, software, and a bit of common sense.</description>
     <language>en-us</language>
     <lastBuildDate>${now}</lastBuildDate>
     <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml" />

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,11 +1,40 @@
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
+import { Link } from "react-router-dom";
+import { resolveHref } from "@/lib/urls";
+
+const MarkdownLink: Components["a"] = ({ node: _node, href, children, ...rest }) => {
+  const link = resolveHref(href);
+  if (link.kind === "internal") {
+    return (
+      <Link to={link.href} {...rest}>
+        {children}
+      </Link>
+    );
+  }
+  if (link.kind === "external") {
+    return (
+      <a href={link.href} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <a href={link.href || undefined} {...rest}>
+      {children}
+    </a>
+  );
+};
 
 export const Markdown = ({ children }: { children: string }) => {
   return (
     <div className="prose-aycarl">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        components={{ a: MarkdownLink }}
+      >
         {children}
       </ReactMarkdown>
     </div>

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,23 @@
+export type ResolvedLink =
+  | { kind: "internal"; href: string } // rendered as a React Router <Link>
+  | { kind: "external"; href: string } // rendered with target="_blank" and safe rel
+  | { kind: "plain"; href: string }; // rendered as-is: #anchor, mailto:, tel:, etc.
+
+const SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+const HTTP = /^https?:\/\//i;
+const BARE_DOMAIN = /^(?:www\.)?[a-z0-9-]+(?:\.[a-z0-9-]+)+(?:[/?#]|$)/i;
+
+// Craft-authored links often omit the protocol ("www.tackshare.com"), which the
+// browser would resolve relative to the current origin. Classify each href so the
+// Markdown renderer can normalize external destinations and keep internal ones
+// on client-side routing.
+export function resolveHref(raw: string | undefined | null): ResolvedLink {
+  const href = (raw ?? "").trim();
+  if (!href || href.startsWith("#")) return { kind: "plain", href };
+  if (href.startsWith("//")) return { kind: "external", href: `https:${href}` };
+  if (href.startsWith("/")) return { kind: "internal", href };
+  if (HTTP.test(href)) return { kind: "external", href };
+  if (SCHEME.test(href)) return { kind: "plain", href };
+  if (BARE_DOMAIN.test(href)) return { kind: "external", href: `https://${href}` };
+  return { kind: "plain", href };
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -15,10 +15,10 @@ const About = () => {
           </h1>
           <div className="space-y-5 text-lg text-foreground/80">
             <p>
-              I'm a full-stack software engineer and solutions architect working on the boundary
-              between product and infrastructure — designing systems that earn their complexity,
-              shipping the smallest version that proves the idea, and helping organizations
-              navigate cloud, data, and platform decisions.
+              I'm an AI solutions engineer and full-stack developer. I help teams figure out
+              where AI can genuinely make their work easier, then I build it — from the first
+              rough demo to something people rely on every day. I like starting small, proving
+              an idea works, and only adding complexity when it earns its keep.
             </p>
             <p>
               Outside of work, and in no particular order, I practice Japanese and Zulu on Duolingo,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -28,7 +28,7 @@ const Index = () => {
         <div className="container relative pt-20 md:pt-32 pb-24 md:pb-40">
           <div className="max-w-4xl">
             <p className="text-sm tracking-widest uppercase text-foreground/60 mb-6 animate-fade-up">
-              Solutions architect · Full-Stack Software Engineer
+              AI Solutions Engineer · Full-stack Developer
             </p>
             <h1 className="wordmark text-[18vw] md:text-[12rem] leading-[0.85] animate-fade-up">
               aycarl<span className="text-orange">.</span>

--- a/src/pages/Links.tsx
+++ b/src/pages/Links.tsx
@@ -32,7 +32,7 @@ const Links = () => {
             Carl<span className="text-yellow">.</span>
           </h1>
           <p className="text-foreground/70 mb-10">
-            Full-stack software engineer &amp; solutions architect.
+            AI solutions engineer &amp; full-stack developer.
           </p>
 
           <nav className="flex flex-col gap-3" aria-label="Contact and profile links">

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -22,7 +22,7 @@ const Post = () => {
   useEffect(() => {
     if (data?.post) document.title = `${data.post.title} — aycarl.`;
     return () => {
-      document.title = "aycarl. — solutions architect";
+      document.title = "aycarl. — AI solutions engineer";
     };
   }, [data]);
 

--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -18,7 +18,7 @@ const Writing = () => {
           eyebrow="Writing"
           title="Notes & essays"
           accent="pink"
-          description="Working notes on systems design, infrastructure, and the craft of being a solutions architect."
+          description="Notes on building useful things with AI, software, and a bit of common sense."
         />
 
         <div className="mt-8 flex flex-wrap items-center gap-3">

--- a/src/test/markdown-links.test.tsx
+++ b/src/test/markdown-links.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { renderToString } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { Markdown } from "@/components/Markdown";
+import { resolveHref } from "@/lib/urls";
+
+const render = (md: string) =>
+  renderToString(
+    <MemoryRouter>
+      <Markdown>{md}</Markdown>
+    </MemoryRouter>
+  );
+
+describe("resolveHref", () => {
+  it("normalizes protocol-less www domains to https and marks them external", () => {
+    expect(resolveHref("www.tackshare.com")).toEqual({
+      kind: "external",
+      href: "https://www.tackshare.com",
+    });
+  });
+
+  it("normalizes bare domains with paths and queries", () => {
+    expect(resolveHref("tackshare.com/pricing?x=1")).toEqual({
+      kind: "external",
+      href: "https://tackshare.com/pricing?x=1",
+    });
+  });
+
+  it("leaves absolute http/https URLs unchanged", () => {
+    expect(resolveHref("http://example.com")).toEqual({ kind: "external", href: "http://example.com" });
+    expect(resolveHref("https://example.com")).toEqual({ kind: "external", href: "https://example.com" });
+    expect(resolveHref("HTTPS://EXAMPLE.COM")).toEqual({ kind: "external", href: "HTTPS://EXAMPLE.COM" });
+  });
+
+  it("upgrades protocol-relative URLs to https", () => {
+    expect(resolveHref("//cdn.example.com/a.js")).toEqual({
+      kind: "external",
+      href: "https://cdn.example.com/a.js",
+    });
+  });
+
+  it("classifies site-relative paths as internal", () => {
+    expect(resolveHref("/writing/some-post")).toEqual({ kind: "internal", href: "/writing/some-post" });
+  });
+
+  it("passes anchors, mailto, and tel through unchanged", () => {
+    expect(resolveHref("#section-2")).toEqual({ kind: "plain", href: "#section-2" });
+    expect(resolveHref("mailto:hi@example.com")).toEqual({ kind: "plain", href: "mailto:hi@example.com" });
+    expect(resolveHref("MAILTO:HI@X.COM")).toEqual({ kind: "plain", href: "MAILTO:HI@X.COM" });
+    expect(resolveHref("tel:+441234567")).toEqual({ kind: "plain", href: "tel:+441234567" });
+  });
+
+  it("treats empty or missing hrefs as plain", () => {
+    expect(resolveHref("")).toEqual({ kind: "plain", href: "" });
+    expect(resolveHref(undefined)).toEqual({ kind: "plain", href: "" });
+  });
+});
+
+describe("Markdown link rendering", () => {
+  it("renders Craft-authored protocol-less links as external (the tackshare bug)", () => {
+    const html = render("[TackShare](www.tackshare.com)");
+    expect(html).toContain('href="https://www.tackshare.com"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("renders absolute URLs as external with the href unchanged", () => {
+    const html = render("[abs](https://example.com/x)");
+    expect(html).toContain('href="https://example.com/x"');
+    expect(html).toContain('target="_blank"');
+  });
+
+  it("renders anchors without target=_blank", () => {
+    const html = render("[anchor](#notes)");
+    expect(html).toContain('href="#notes"');
+    expect(html).not.toContain('target="_blank"');
+  });
+
+  it("renders mailto links without target=_blank", () => {
+    const html = render("[mail](mailto:hi@example.com)");
+    expect(html).toContain('href="mailto:hi@example.com"');
+    expect(html).not.toContain('target="_blank"');
+  });
+
+  it("renders internal paths as same-tab router links", () => {
+    const html = render("[post](/writing/foo)");
+    expect(html).toContain('href="/writing/foo"');
+    expect(html).not.toContain('target="_blank"');
+  });
+
+  it("still autolinks bare www text via remark-gfm", () => {
+    const html = render("visit www.tackshare.com today");
+    expect(html).toContain('href="http://www.tackshare.com"');
+    expect(html).toContain('target="_blank"');
+  });
+});


### PR DESCRIPTION
Fixes #50.

## What

**Link fix (#50):** Craft-authored links without a protocol (`www.tackshare.com`) rendered as relative URLs and landed on `aycarl.com/www.tackshare.com` (SPA catch-all). Now:

- New `src/lib/urls.ts` — a pure `resolveHref` classifier: bare/`www.` domains → normalized to `https://` + external; `/paths` → internal (React Router `<Link>`); anchors/`mailto:` → untouched.
- `Markdown.tsx` gets a custom `a` renderer using it; external links open in a new tab with `rel="noopener noreferrer"`.
- 13 new tests (`src/test/markdown-links.test.tsx`) covering the classifier and rendered output, including the exact TackShare repro and a remark-gfm autolink regression guard.

**Rebrand:** "solutions architect" → "AI Solutions Engineer · Full-stack Developer" across the homepage tagline, Links bio, Post tab-title fallback; plainer-language About intro; new writing tagline ("Notes on building useful things with AI, software, and a bit of common sense.") on the Writing page and RSS feed description.

## Verification (headless Chromium against the production preview build)

- The real post *How I Use AI: A Documentation-Driven Approach* now renders the Tackshare link as `https://www.tackshare.com` with `target="_blank" rel="noopener noreferrer"`; clicking opens a new tab while the original tab stays on the post.
- Leaving a post resets the tab title to `aycarl. — AI solutions engineer`.
- Homepage/About/Links render the new branding correctly.
- `npm run test` (15 passed), `npm run build` clean; lint issues are pre-existing (shadcn scaffolding / tailwind config only).

## Note for after merge

⚠️ `www.tackshare.com` has **no DNS record** — only apex `tackshare.com` resolves. The link in the Craft post should be edited to `tackshare.com` (or add a `www` CNAME), otherwise the now-correctly-external link opens a DNS error page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)