### PR TITLE
SEO: AI-crawler content visibility (article-body injection, llms.txt)

### DIFF
--- a/functions/projects/[slug].ts
+++ b/functions/projects/[slug].ts
@@ -1,8 +1,14 @@
-import { fetchPublishedProjects } from "../../src/lib/craft-edge";
+import { fetchPublishedProjects, fetchBlockMarkdown } from "../../src/lib/craft-edge";
 import { injectMeta, SITE_URL, breadcrumbJsonLd } from "../../src/lib/seo";
+import { markdownToHtml, buildArticleShell, injectArticleBody } from "../../src/lib/markdown-edge";
+import { isBotUserAgent } from "../../src/lib/crawler-ua";
 
-export async function onRequest(context: { params: Record<string, string>; next: () => Promise<Response> }) {
-  const { params, next } = context;
+export async function onRequest(context: {
+  request: Request;
+  params: Record<string, string>;
+  next: () => Promise<Response>;
+}) {
+  const { request, params, next } = context;
   const slug = params.slug as string;
 
   try {
@@ -10,8 +16,8 @@ export async function onRequest(context: { params: Record<string, string>; next:
     const project = projects.find((p) => p.slug === slug);
     if (!project) return next();
 
-    const response = await next();
-    return injectMeta(response, {
+    let response = await next();
+    response = injectMeta(response, {
       title: `${project.title} — aycarl.`,
       description: `${project.year} · ${project.role} — ${project.summary}`,
       path: `/projects/${slug}`,
@@ -25,6 +31,23 @@ export async function onRequest(context: { params: Record<string, string>; next:
         ]),
       ],
     });
+
+    if (isBotUserAgent(request.headers.get("User-Agent"))) {
+      try {
+        const markdown = await fetchBlockMarkdown(project.id);
+        const bodyHtml = markdownToHtml(markdown);
+        const shell = buildArticleShell({
+          title: project.title,
+          meta: `${project.year} · ${project.role}`,
+          bodyHtml,
+        });
+        response = injectArticleBody(response, shell);
+      } catch (err) {
+        console.error("projects/[slug] article-body injection error:", err);
+      }
+    }
+
+    return response;
   } catch (err) {
     console.error("projects/[slug] edge meta error:", err);
     return next();

--- a/functions/writing/[slug].ts
+++ b/functions/writing/[slug].ts
@@ -1,8 +1,14 @@
-import { fetchPublishedPosts } from "../../src/lib/craft-edge";
+import { fetchPublishedPosts, fetchBlockMarkdown } from "../../src/lib/craft-edge";
 import { injectMeta, SITE_URL, blogPostingJsonLd, breadcrumbJsonLd } from "../../src/lib/seo";
+import { markdownToHtml, buildArticleShell, injectArticleBody } from "../../src/lib/markdown-edge";
+import { isBotUserAgent } from "../../src/lib/crawler-ua";
 
-export async function onRequest(context: { params: Record<string, string>; next: () => Promise<Response> }) {
-  const { params, next } = context;
+export async function onRequest(context: {
+  request: Request;
+  params: Record<string, string>;
+  next: () => Promise<Response>;
+}) {
+  const { request, params, next } = context;
   const slug = params.slug as string;
 
   try {
@@ -10,8 +16,8 @@ export async function onRequest(context: { params: Record<string, string>; next:
     const post = posts.find((p) => p.slug === slug);
     if (!post) return next(); // no matching published post — default shell
 
-    const response = await next();
-    return injectMeta(response, {
+    let response = await next();
+    response = injectMeta(response, {
       title: `${post.title} — aycarl.`,
       description: post.excerpt,
       path: `/writing/${slug}`,
@@ -26,6 +32,24 @@ export async function onRequest(context: { params: Record<string, string>; next:
         ]),
       ],
     });
+
+    // Non-JS-executing crawlers (GPTBot, ClaudeBot, link unfurlers, ...) get
+    // the article body pre-rendered into #root; humans get the unchanged
+    // client-rendered app. See src/lib/crawler-ua.ts for why this is gated
+    // rather than always-on.
+    if (isBotUserAgent(request.headers.get("User-Agent"))) {
+      try {
+        const markdown = await fetchBlockMarkdown(post.id);
+        const bodyHtml = markdownToHtml(markdown);
+        const shell = buildArticleShell({ title: post.title, meta: post.date || undefined, bodyHtml });
+        response = injectArticleBody(response, shell);
+      } catch (err) {
+        console.error("writing/[slug] article-body injection error:", err);
+        // Meta-only response (already built above) is still correct.
+      }
+    }
+
+    return response;
   } catch (err) {
     console.error("writing/[slug] edge meta error:", err);
     return next(); // always fall back gracefully

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,16 @@
+# aycarl.
+
+> Carl — AI solutions engineer and full-stack developer. Personal site with
+> writing on AI-assisted development, systems design, and infrastructure,
+> plus selected project case studies.
+
+## Docs
+
+- [Writing](https://aycarl.com/writing): Essays and notes, most recent first.
+- [Projects](https://aycarl.com/projects): Selected project case studies.
+- [About](https://aycarl.com/about): Background and contact.
+
+## Optional
+
+- [RSS feed](https://aycarl.com/feed.xml): Machine-readable feed of all posts.
+- [Sitemap](https://aycarl.com/sitemap.xml): Full list of indexable URLs.

--- a/src/lib/crawler-ua.ts
+++ b/src/lib/crawler-ua.ts
@@ -1,0 +1,49 @@
+// Known non-JS-executing crawlers and link unfurlers. Used to gate edge-side
+// article-body injection (see markdown-edge.ts) so humans get the same
+// client-rendered experience as today, and only these UAs get pre-rendered
+// content — see functions/writing/[slug].ts / functions/projects/[slug].ts.
+export const BOT_USER_AGENTS = [
+  // AI / LLM crawlers
+  "GPTBot",
+  "ChatGPT-User",
+  "OAI-SearchBot",
+  "ClaudeBot",
+  "Claude-Web",
+  "anthropic-ai",
+  "PerplexityBot",
+  "Perplexity-User",
+  "Google-Extended",
+  "Applebot-Extended",
+  "CCBot",
+  "Bytespider",
+  "Amazonbot",
+  "Meta-ExternalAgent",
+  "cohere-ai",
+  "Diffbot",
+  "YouBot",
+  // Traditional search crawlers
+  "Googlebot",
+  "Bingbot",
+  "DuckDuckBot",
+  "Baiduspider",
+  "YandexBot",
+  // Social / link unfurlers
+  "facebookexternalhit",
+  "Facebot",
+  "Twitterbot",
+  "LinkedInBot",
+  "Slackbot",
+  "TelegramBot",
+  "WhatsApp",
+  "Discordbot",
+  "redditbot",
+  "SkypeUriPreview",
+  "vkShare",
+  "Pinterest",
+] as const;
+
+export function isBotUserAgent(ua: string | null | undefined): boolean {
+  if (!ua) return false;
+  const lower = ua.toLowerCase();
+  return BOT_USER_AGENTS.some((token) => lower.includes(token.toLowerCase()));
+}

--- a/src/lib/markdown-edge.ts
+++ b/src/lib/markdown-edge.ts
@@ -1,0 +1,122 @@
+// Dependency-free markdown -> HTML conversion for edge-side crawler
+// visibility (see functions/writing/[slug].ts, functions/projects/[slug].ts).
+//
+// This targets the actual feature surface Craft content uses today
+// (headings, paragraphs, bold/italic, inline code, fenced code blocks,
+// blockquotes, lists - including "loose" lists, since Craft emits each list
+// item as its own block, joined with blank lines by fetchBlockMarkdown),
+// not full CommonMark/GFM. Unknown constructs degrade to escaped plain
+// text - never to broken or unbalanced HTML. This is a strictly smaller
+// feature set than src/components/Markdown.tsx (react-markdown + remark-gfm);
+// the goal is crawler-readable text, not pixel parity with the client render.
+
+import { resolveHref } from "./urls";
+
+// HTMLRewriter is a Cloudflare Workers runtime global (edge-only) - declared
+// locally the same way src/lib/seo.ts does, since ambient declarations in a
+// module file are file-scoped, not global.
+interface RewriterElement {
+  setInnerContent(content: string, options?: { html?: boolean }): void;
+}
+
+declare class HTMLRewriter {
+  on(selector: string, handlers: { element?(el: RewriterElement): void }): HTMLRewriter;
+  transform(response: Response): Response;
+}
+
+const escapeHtml = (s: string): string => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const escapeAttr = (s: string): string => escapeHtml(s).replace(/"/g, "&quot;");
+
+// Marker template for stashing code-span HTML during inline processing.
+// Uses an unlikely-to-collide ASCII token (not plain digits/whitespace) so a
+// bare number in prose, or a code span immediately followed by punctuation
+// (e.g. "`code`."), can't be mistaken for or break the placeholder.
+const codeSpanToken = (i: number): string => `@@CODESPAN${i}@@`;
+const CODE_SPAN_MARKER = /@@CODESPAN(\d+)@@/g;
+
+// Inline spans: code > images > links > bold > italic, so `**not bold**`
+// inside `inline code` is left alone and image syntax isn't half-eaten by
+// the link matcher.
+function inline(text: string): string {
+  const codeSpans: string[] = [];
+  let out = text.replace(/`([^`]+)`/g, (_match, code: string) => {
+    codeSpans.push(`<code>${escapeHtml(code)}</code>`);
+    return codeSpanToken(codeSpans.length - 1);
+  });
+
+  out = escapeHtml(out);
+
+  out = out.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt: string, src: string) => {
+    return `<img alt="${escapeAttr(alt)}" src="${escapeAttr(src)}" loading="lazy" />`;
+  });
+
+  out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label: string, href: string) => {
+    const link = resolveHref(href);
+    const attrs = link.kind === "external" ? ' target="_blank" rel="noopener noreferrer"' : "";
+    return `<a href="${escapeAttr(link.href)}"${attrs}>${label}</a>`;
+  });
+
+  out = out.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  out = out.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, "<em>$1</em>");
+
+  out = out.replace(CODE_SPAN_MARKER, (_match, i: string) => codeSpans[Number(i)]);
+  return out;
+}
+
+const LIST_ITEM = /^\s*(?:[-*+]|\d+\.)\s+/;
+
+export function markdownToHtml(markdown: string): string {
+  const blocks = markdown.trim().split(/\n{2,}/).filter(Boolean);
+  const html: string[] = [];
+  let i = 0;
+
+  while (i < blocks.length) {
+    const block = blocks[i];
+    const fence = /^```[^\n]*\n([\s\S]*?)\n?```$/.exec(block);
+    const heading = /^(#{1,6})\s+(.*)$/.exec(block);
+
+    if (fence) {
+      html.push(`<pre><code>${escapeHtml(fence[1])}</code></pre>`);
+      i += 1;
+    } else if (heading) {
+      const level = heading[1].length;
+      html.push(`<h${level}>${inline(heading[2])}</h${level}>`);
+      i += 1;
+    } else if (/^>\s?/.test(block)) {
+      html.push(`<blockquote><p>${inline(block.replace(/^>\s?/gm, ""))}</p></blockquote>`);
+      i += 1;
+    } else if (LIST_ITEM.test(block)) {
+      // Craft emits each list item as its own block, joined with blank lines
+      // by fetchBlockMarkdown/fetchPublishedPosts - merge consecutive
+      // list-item blocks into a single list rather than fragmenting them.
+      const ordered = /^\s*\d+\.\s/.test(block);
+      const items: string[] = [];
+      while (i < blocks.length && LIST_ITEM.test(blocks[i])) {
+        items.push(`<li>${inline(blocks[i].replace(LIST_ITEM, ""))}</li>`);
+        i += 1;
+      }
+      const tag = ordered ? "ol" : "ul";
+      html.push(`<${tag}>${items.join("")}</${tag}>`);
+    } else {
+      html.push(`<p>${inline(block)}</p>`);
+      i += 1;
+    }
+  }
+
+  return html.join("\n");
+}
+
+export function buildArticleShell(opts: { title: string; meta?: string; bodyHtml: string }): string {
+  const metaLine = opts.meta ? `<p>${escapeHtml(opts.meta)}</p>` : "";
+  return `<article><h1>${escapeHtml(opts.title)}</h1>${metaLine}${opts.bodyHtml}</article>`;
+}
+
+export function injectArticleBody(response: Response, articleHtml: string): Response {
+  return new HTMLRewriter()
+    .on("#root", {
+      element(el: RewriterElement) {
+        el.setInnerContent(articleHtml, { html: true });
+      },
+    })
+    .transform(response);
+}

--- a/src/test/markdown-edge.test.ts
+++ b/src/test/markdown-edge.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { markdownToHtml } from "@/lib/markdown-edge";
+
+describe("markdownToHtml", () => {
+  it("renders headings, paragraphs, bold, italic, and inline code", () => {
+    const html = markdownToHtml(
+      "## A heading\n\nA paragraph with **bold**, *italic*, and `inline code`.",
+    );
+    expect(html).toContain("<h2>A heading</h2>");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).toContain("<code>inline code</code>");
+  });
+
+  it("does not let a code span immediately followed by punctuation break the placeholder", () => {
+    const html = markdownToHtml("Use `AGENTS.md`.");
+    expect(html).toBe("<p>Use <code>AGENTS.md</code>.</p>");
+  });
+
+  it("does not mistake a bare number in prose for a code-span placeholder", () => {
+    const html = markdownToHtml("There are 4 items in `the list`.");
+    expect(html).toContain("There are 4 items in");
+    expect(html).toContain("<code>the list</code>");
+  });
+
+  it("merges consecutive blank-line-separated list items into one list (Craft's loose-list block shape)", () => {
+    // Craft emits each list item as its own block; fetchBlockMarkdown joins
+    // them with blank lines, exactly like this real sample from
+    // "How I Use AI: A Documentation-Driven Approach".
+    const markdown = [
+      "Here is how I break it down:",
+      '- **The "What & Why"**: My `PRODUCT.md` file serves as a living spec.',
+      "- **The \"How & Rules\"**: Inside `docs/architecture/`, I keep ADRs.",
+      "- **The \"Action\"**: Numbered markdown files.",
+    ].join("\n\n");
+    const html = markdownToHtml(markdown);
+    expect(html.match(/<ul>/g)).toHaveLength(1);
+    expect(html.match(/<li>/g)).toHaveLength(3);
+    expect(html).toContain("</ul>");
+  });
+
+  it("renders ordered lists distinctly from unordered lists", () => {
+    const html = markdownToHtml("1. First\n\n2. Second");
+    expect(html).toContain("<ol>");
+    expect(html.match(/<li>/g)).toHaveLength(2);
+  });
+
+  it("classifies an internal link and an external bare-domain link like the client renderer", () => {
+    const html = markdownToHtml("See [Tackshare](tackshare.com) and [the archive](/writing/archive).");
+    expect(html).toContain('<a href="https://tackshare.com" target="_blank" rel="noopener noreferrer">Tackshare</a>');
+    expect(html).toContain('<a href="/writing/archive">the archive</a>');
+  });
+
+  it("escapes HTML in plain text so it can't be mistaken for markup", () => {
+    const html = markdownToHtml("A <script>alert(1)</script> in prose.");
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("renders a fenced code block without syntax-highlight markup", () => {
+    const html = markdownToHtml("```\nconst x = 1;\n```");
+    expect(html).toBe("<pre><code>const x = 1;</code></pre>");
+  });
+
+  it("renders a blockquote", () => {
+    const html = markdownToHtml("> A quoted line.");
+    expect(html).toBe("<blockquote><p>A quoted line.</p></blockquote>");
+  });
+});


### PR DESCRIPTION
## Summary

Package 3 of 3, stacked on #55. Covers #52 Phase 3.

- `src/lib/markdown-edge.ts` — dependency-free markdown→HTML converter sized to what Craft content actually contains (verified against the live API): headings, paragraphs, bold/italic, inline code, fenced code, blockquotes, and lists — including "loose" lists, since Craft emits each list item as its own block and `fetchBlockMarkdown` joins them with blank lines
- `src/lib/crawler-ua.ts` — known AI/search crawler and link-unfurler User-Agent list
- Both slug functions now inject the full article body into `#root` via `HTMLRewriter`, gated on User-Agent
- `public/llms.txt` per the informal llms.txt convention

### Why gated on User-Agent, not always-on

`src/main.tsx` does a full `createRoot().render()`, not hydration. Always-injecting would cause a double-flash for every human visitor: real content (edge-injected) → React's loading skeleton → real content again (client-fetched). Gating means humans see exactly what they see today; only known bot/unfurler UAs get the pre-rendered body. Both paths render identical content — no cloaking risk, same category of technique as the "dynamic rendering" approach search engines already treat as legitimate.

## Test plan

- [x] `npm run build`, `npm run test` (31/31 passing, includes 9 new markdown-edge tests grounded in a real post's actual content), `npm run lint` (zero new errors)
- [x] `wrangler pages dev`: confirmed human UA still gets an empty `#root` (byte-identical to before this PR)
- [x] Confirmed `GPTBot`/`ClaudeBot`/`facebookexternalhit` all get the full article injected, with a distinctive sentence from the real post present verbatim
- [x] Confirmed loose-list merging on real content (3-item and another 3-item list in "How I Use AI..." render as two separate `<ul>` with 6 `<li>` total, not fragmented)
- [x] Confirmed bare-domain link (`tackshare.com`) resolves to a proper external anchor, matching client-side `resolveHref` behavior
- [x] Confirmed HTML in prose text is escaped, not executed
- [x] Verified project pages get the same treatment
- [x] `llms.txt` serves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)