### PR TITLE
SEO: sitemap, per-route static meta, client title sync, JSON-LD

### DIFF
--- a/functions/about.ts
+++ b/functions/about.ts
@@ -1,0 +1,6 @@
+import { injectMeta, ROUTE_META } from "../src/lib/seo";
+
+export async function onRequest(context: { next: () => Promise<Response> }) {
+  const response = await context.next();
+  return injectMeta(response, { ...ROUTE_META["/about"], path: "/about", type: "website" });
+}

--- a/functions/experience.ts
+++ b/functions/experience.ts
@@ -1,0 +1,6 @@
+import { injectMeta, ROUTE_META } from "../src/lib/seo";
+
+export async function onRequest(context: { next: () => Promise<Response> }) {
+  const response = await context.next();
+  return injectMeta(response, { ...ROUTE_META["/experience"], path: "/experience", type: "website" });
+}

--- a/functions/links.ts
+++ b/functions/links.ts
@@ -1,0 +1,7 @@
+import { injectMeta, ROUTE_META } from "../src/lib/seo";
+
+export async function onRequest(context: { next: () => Promise<Response> }) {
+  const response = await context.next();
+  const meta = ROUTE_META["/links"];
+  return injectMeta(response, { ...meta, path: "/links", type: "website", noindex: meta.noindex });
+}

--- a/functions/projects/[slug].ts
+++ b/functions/projects/[slug].ts
@@ -1,7 +1,7 @@
 import { fetchPublishedProjects } from "../../src/lib/craft-edge";
-import { injectMeta } from "../../src/lib/seo";
+import { injectMeta, SITE_URL, breadcrumbJsonLd } from "../../src/lib/seo";
 
-export async function onRequest(context: any) {
+export async function onRequest(context: { params: Record<string, string>; next: () => Promise<Response> }) {
   const { params, next } = context;
   const slug = params.slug as string;
 
@@ -18,6 +18,12 @@ export async function onRequest(context: any) {
       type: "article",
       image: project.ogImage,
       publishedTime: project.date || undefined,
+      jsonLd: [
+        breadcrumbJsonLd([
+          { name: "Projects", url: `${SITE_URL}/projects` },
+          { name: project.title, url: `${SITE_URL}/projects/${slug}` },
+        ]),
+      ],
     });
   } catch (err) {
     console.error("projects/[slug] edge meta error:", err);

--- a/functions/projects/index.ts
+++ b/functions/projects/index.ts
@@ -1,0 +1,6 @@
+import { injectMeta, ROUTE_META } from "../../src/lib/seo";
+
+export async function onRequest(context: { next: () => Promise<Response> }) {
+  const response = await context.next();
+  return injectMeta(response, { ...ROUTE_META["/projects"], path: "/projects", type: "website" });
+}

--- a/functions/sitemap.xml.ts
+++ b/functions/sitemap.xml.ts
@@ -1,0 +1,22 @@
+import { fetchPublishedPosts, fetchPublishedProjects } from "../src/lib/craft-edge";
+import { SITE_URL, STATIC_ROUTES, buildSitemapXml, type SitemapUrl } from "../src/lib/seo";
+
+export async function onRequest(): Promise<Response> {
+  const urls: SitemapUrl[] = STATIC_ROUTES.map((path) => ({ loc: path === "/" ? SITE_URL : `${SITE_URL}${path}` }));
+
+  try {
+    const [posts, projects] = await Promise.all([fetchPublishedPosts(), fetchPublishedProjects()]);
+    for (const p of posts) urls.push({ loc: `${SITE_URL}/writing/${p.slug}`, lastmod: p.date || undefined });
+    for (const p of projects) urls.push({ loc: `${SITE_URL}/projects/${p.slug}`, lastmod: p.date || undefined });
+  } catch (err) {
+    console.error("sitemap.xml: Craft fetch failed, serving static routes only:", err);
+    // Deliberately no throw — degrade to a static-only sitemap rather than 500.
+  }
+
+  return new Response(buildSitemapXml(urls), {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/functions/writing/[slug].ts
+++ b/functions/writing/[slug].ts
@@ -1,7 +1,7 @@
 import { fetchPublishedPosts } from "../../src/lib/craft-edge";
-import { injectMeta } from "../../src/lib/seo";
+import { injectMeta, SITE_URL, blogPostingJsonLd, breadcrumbJsonLd } from "../../src/lib/seo";
 
-export async function onRequest(context: any) {
+export async function onRequest(context: { params: Record<string, string>; next: () => Promise<Response> }) {
   const { params, next } = context;
   const slug = params.slug as string;
 
@@ -18,6 +18,13 @@ export async function onRequest(context: any) {
       type: "article",
       image: post.ogImage, // undefined today — injectMeta falls back to the default OG image
       publishedTime: post.date || undefined,
+      jsonLd: [
+        blogPostingJsonLd({ title: post.title, slug, date: post.date, excerpt: post.excerpt }),
+        breadcrumbJsonLd([
+          { name: "Writing", url: `${SITE_URL}/writing` },
+          { name: post.title, url: `${SITE_URL}/writing/${slug}` },
+        ]),
+      ],
     });
   } catch (err) {
     console.error("writing/[slug] edge meta error:", err);

--- a/functions/writing/archive.ts
+++ b/functions/writing/archive.ts
@@ -1,0 +1,6 @@
+import { injectMeta, ROUTE_META } from "../../src/lib/seo";
+
+export async function onRequest(context: { next: () => Promise<Response> }) {
+  const response = await context.next();
+  return injectMeta(response, { ...ROUTE_META["/writing/archive"], path: "/writing/archive", type: "website" });
+}

--- a/functions/writing/index.ts
+++ b/functions/writing/index.ts
@@ -1,0 +1,6 @@
+import { injectMeta, ROUTE_META } from "../../src/lib/seo";
+
+export async function onRequest(context: { next: () => Promise<Response> }) {
+  const response = await context.next();
+  return injectMeta(response, { ...ROUTE_META["/writing"], path: "/writing", type: "website" });
+}

--- a/functions/writing/search.ts
+++ b/functions/writing/search.ts
@@ -1,0 +1,7 @@
+import { injectMeta, ROUTE_META } from "../../src/lib/seo";
+
+export async function onRequest(context: { next: () => Promise<Response> }) {
+  const response = await context.next();
+  const meta = ROUTE_META["/writing/search"];
+  return injectMeta(response, { ...meta, path: "/writing/search", type: "website", noindex: meta.noindex });
+}

--- a/functions/writing/tag/[tag].ts
+++ b/functions/writing/tag/[tag].ts
@@ -1,0 +1,14 @@
+import { injectMeta } from "../../../src/lib/seo";
+
+export async function onRequest(context: { params: Record<string, string>; next: () => Promise<Response> }) {
+  const { params, next } = context;
+  const tag = decodeURIComponent((params.tag as string) || "");
+  const response = await next();
+  if (!tag) return response;
+  return injectMeta(response, {
+    title: `#${tag} — Writing — aycarl.`,
+    description: `Posts tagged #${tag} on aycarl.`,
+    path: `/writing/tag/${encodeURIComponent(tag)}`,
+    type: "website",
+  });
+}

--- a/index.html
+++ b/index.html
@@ -34,6 +34,17 @@
     <meta name="twitter:image" content="https://aycarl.com/og-default.png" />
 
     <link rel="alternate" type="application/rss+xml" title="aycarl — Writing" href="/feed.xml" />
+
+    <!--
+      Person + WebSite JSON-LD, static rather than edge-injected: Cloudflare
+      Pages Functions routing does not reliably invoke a function for the
+      bare "/" path when a literal index.html asset exists at that path
+      (confirmed against wrangler pages dev; see functions/*.ts history for
+      the removed functions/index.ts). Keep this in sync with
+      personJsonLd()/webSiteJsonLd() in src/lib/seo.ts.
+    -->
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Person","name":"aycarl.","url":"https://aycarl.com","jobTitle":"AI Solutions Engineer","sameAs":["https://github.com/aycarl","https://www.linkedin.com/in/aycarl"]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"aycarl.","url":"https://aycarl.com","potentialAction":{"@type":"SearchAction","target":"https://aycarl.com/writing/search?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+Sitemap: https://aycarl.com/sitemap.xml

--- a/src/hooks/usePageMeta.ts
+++ b/src/hooks/usePageMeta.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { SITE_URL } from "@/lib/seo";
+
+interface PageMetaOptions {
+  title: string;
+  description: string;
+  noindex?: boolean;
+  /** Defaults to the current location's pathname. */
+  canonicalPath?: string;
+}
+
+function upsertMeta(name: string, content: string) {
+  let tag = document.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
+  if (!tag) {
+    tag = document.createElement("meta");
+    tag.setAttribute("name", name);
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute("content", content);
+}
+
+// Client-side counterpart to src/lib/seo.ts#injectMeta: keeps document.title,
+// the description meta, and the canonical link in sync on SPA navigation
+// (the edge-injected tags only apply to the first, server-rendered load).
+export function usePageMeta({ title, description, noindex, canonicalPath }: PageMetaOptions) {
+  const location = useLocation();
+
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = title;
+    upsertMeta("description", description);
+
+    let canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    if (!canonical) {
+      canonical = document.createElement("link");
+      canonical.setAttribute("rel", "canonical");
+      document.head.appendChild(canonical);
+    }
+    canonical.setAttribute("href", `${SITE_URL}${canonicalPath ?? location.pathname}`);
+
+    const robots = document.querySelector<HTMLMetaElement>('meta[name="robots"]');
+    if (noindex) {
+      upsertMeta("robots", "noindex, follow");
+    } else if (robots) {
+      robots.setAttribute("content", "index, follow");
+    }
+
+    return () => {
+      document.title = previousTitle;
+    };
+  }, [title, description, noindex, canonicalPath, location.pathname]);
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -8,7 +8,7 @@
 // block, which has no baseline placeholder to rewrite and is therefore
 // appended.
 
-import { SITE_URL } from "../content/links";
+import { SITE_URL, GITHUB_URL, LINKEDIN_URL } from "../content/links";
 
 // HTMLRewriter is a Cloudflare Workers runtime global (edge-only). This file
 // is imported from both src/ (typechecked against DOM lib) and functions/
@@ -41,11 +41,46 @@ export interface RouteMeta {
   noindex?: boolean;
 }
 
-// Static-route entries are owned by the SEO/sitemap work; this file only
-// seeds "/" so injectMeta has a real default to fall back on.
+// Single source of truth for static-route meta, consumed by both the
+// per-route edge functions (functions/*.ts) and the client-side usePageMeta
+// hook, so server- and client-rendered titles/descriptions never diverge.
 export const ROUTE_META: Record<string, RouteMeta> = {
   "/": { title: DEFAULT_TITLE, description: DEFAULT_DESCRIPTION },
+  "/about": {
+    title: "About — aycarl.",
+    description: "Background, approach, and how to get in touch with Carl — AI solutions engineer and full-stack developer.",
+  },
+  "/experience": {
+    title: "Experience — aycarl.",
+    description: "A timeline of roles, projects, and growth across design, engineering, and leadership.",
+  },
+  "/links": {
+    title: "Links — aycarl.",
+    description: "CV, LinkedIn, GitHub, and email — quick links for Carl, AI solutions engineer & full-stack developer.",
+    noindex: true, // thin QR-code destination page duplicating primary nav — not worth indexing separately
+  },
+  "/writing": {
+    title: "Writing — aycarl.",
+    description: "Notes on building useful things with AI, software, and a bit of common sense.",
+  },
+  "/writing/archive": {
+    title: "Archive — Writing — aycarl.",
+    description: "The full archive of every post, filterable by title or tag.",
+  },
+  "/writing/search": {
+    title: "Search — Writing — aycarl.",
+    description: "Search across all posts on aycarl.",
+    noindex: true, // parametric ?q= results — no unique canonical value to index
+  },
+  "/projects": {
+    title: "Projects — aycarl.",
+    description: "Selected work across systems design, infrastructure, and platform engineering.",
+  },
 };
+
+// Static routes worth listing in sitemap.xml — mirrors the literal-path
+// routes in src/App.tsx, minus noindex-marked entries above (/links, /writing/search).
+export const STATIC_ROUTES = ["/", "/writing", "/writing/archive", "/projects", "/about", "/experience"] as const;
 
 export const escapeHtml = (input: string): string =>
   input
@@ -209,4 +244,76 @@ export function buildSitemapXml(urls: SitemapUrl[]): string {
     })
     .join("\n");
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>\n`;
+}
+
+// ---------- JSON-LD structured data ----------
+// Consumed via injectMeta's `jsonLd` option (appended as a single <script>
+// block per response — see the jsonLd branch in injectMeta above).
+
+export function personJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: SITE_NAME,
+    url: SITE_URL,
+    jobTitle: "AI Solutions Engineer",
+    sameAs: [GITHUB_URL, LINKEDIN_URL],
+  };
+}
+
+export function webSiteJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    url: SITE_URL,
+    potentialAction: {
+      "@type": "SearchAction",
+      target: `${SITE_URL}/writing/search?q={search_term_string}`,
+      "query-input": "required name=search_term_string",
+    },
+  };
+}
+
+export interface BlogPostingInput {
+  title: string;
+  slug: string;
+  date?: string;
+  excerpt: string;
+}
+
+export function blogPostingJsonLd(post: BlogPostingInput) {
+  const url = `${SITE_URL}/writing/${post.slug}`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.excerpt,
+    url,
+    // Craft only exposes a single "date" property (no separate "last updated"
+    // field), so datePublished/dateModified are always identical.
+    datePublished: post.date || undefined,
+    dateModified: post.date || undefined,
+    author: { "@type": "Person", name: SITE_NAME, url: SITE_URL },
+    publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+  };
+}
+
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export function breadcrumbJsonLd(items: BreadcrumbItem[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
 }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -3,8 +3,11 @@ import { Blob } from "@/components/Blob";
 import { FileText, Mail } from "lucide-react";
 import { BrandGithub, BrandLinkedin } from "@/components/icons/BrandIcons";
 import { CONTACT_EMAIL, GITHUB_URL, LINKEDIN_URL } from "@/content/links";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { ROUTE_META } from "@/lib/seo";
 
 const About = () => {
+  usePageMeta(ROUTE_META["/about"]);
   return (
     <SiteLayout>
       <section className="container py-16 md:py-24 grid grid-cols-1 md:grid-cols-12 gap-12">

--- a/src/pages/Archive.tsx
+++ b/src/pages/Archive.tsx
@@ -6,6 +6,8 @@ import { SiteLayout } from "@/components/SiteLayout";
 import { PageHero } from "@/components/PageHero";
 import { fetchPosts } from "@/lib/craft";
 import { Input } from "@/components/ui/input";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { ROUTE_META } from "@/lib/seo";
 
 const formatDate = (d: string) =>
   new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
@@ -13,6 +15,7 @@ const formatDate = (d: string) =>
 const yearOf = (d: string) => (d ? new Date(d).getFullYear() : 0);
 
 const Archive = () => {
+  usePageMeta(ROUTE_META["/writing/archive"]);
   const { data: posts, isLoading, error } = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
   const [filter, setFilter] = useState("");
 

--- a/src/pages/Experience.tsx
+++ b/src/pages/Experience.tsx
@@ -3,6 +3,8 @@ import { PageHero } from "@/components/PageHero";
 import { experiences } from "@/content/experience";
 import { education } from "@/content/education";
 import { skillCategories } from "@/content/skills";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { ROUTE_META } from "@/lib/seo";
 
 const accentDot: Record<string, string> = {
   sky: "bg-sky",
@@ -19,6 +21,7 @@ const getAccentColor = (index: number): keyof typeof accentDot => {
 };
 
 const Experience = () => {
+  usePageMeta(ROUTE_META["/experience"]);
   return (
     <SiteLayout>
       {/* Header */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,8 @@ import { HeroBlobField } from "@/components/Blob";
 import { PostListItem } from "@/components/PostListItem";
 import { fetchPosts, fetchProjects } from "@/lib/craft";
 import { ArrowUpRight } from "lucide-react";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { ROUTE_META } from "@/lib/seo";
 
 const accentDot: Record<string, string> = {
   sky: "bg-sky",
@@ -15,6 +17,7 @@ const accentDot: Record<string, string> = {
 };
 
 const Index = () => {
+  usePageMeta(ROUTE_META["/"]);
   const { data: allPosts } = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
   const { data: allProjects } = useQuery({ queryKey: ["projects"], queryFn: fetchProjects });
   const posts = (allPosts ?? []).slice(0, 3);

--- a/src/pages/Links.tsx
+++ b/src/pages/Links.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { ArrowRight, FileText, Mail } from "lucide-react";
 import { SiteLayout } from "@/components/SiteLayout";
 import { BrandGithub, BrandLinkedin } from "@/components/icons/BrandIcons";
 import { CONTACT_EMAIL, GITHUB_URL, LINKEDIN_URL } from "@/content/links";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { ROUTE_META } from "@/lib/seo";
 
 const dots = ["bg-sky", "bg-green", "bg-yellow", "bg-pink", "bg-orange"];
 
@@ -11,13 +12,7 @@ const linkItemClass =
   "inline-flex w-full items-center gap-3 rounded-full border border-border px-6 py-4 text-sm hover:bg-secondary transition-colors";
 
 const Links = () => {
-  useEffect(() => {
-    const previousTitle = document.title;
-    document.title = "Links — aycarl.";
-    return () => {
-      document.title = previousTitle;
-    };
-  }, []);
+  usePageMeta(ROUTE_META["/links"]);
 
   return (
     <SiteLayout>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import { ArrowUpRight } from "lucide-react";
 import { SiteLayout } from "@/components/SiteLayout";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 const exploreLinks = [
   { to: "/", label: "Go home", description: "Start from the landing page." },
@@ -16,15 +17,14 @@ const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    const previousTitle = document.title;
-
     console.error("404 Error: User attempted to access non-existent route:", location.pathname);
-    document.title = "404 — aycarl.";
-
-    return () => {
-      document.title = previousTitle;
-    };
   }, [location.pathname]);
+
+  usePageMeta({
+    title: "404 — aycarl.",
+    description: "This page doesn't exist. Explore aycarl's writing, projects, and experience instead.",
+    noindex: true,
+  });
 
   return (
     <SiteLayout>

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Markdown } from "@/components/Markdown";
 import { fetchPostBySlug } from "@/lib/craft";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 const formatDate = (d: string) =>
   new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
@@ -19,12 +19,11 @@ const Post = () => {
     enabled: !!slug,
   });
 
-  useEffect(() => {
-    if (data?.post) document.title = `${data.post.title} — aycarl.`;
-    return () => {
-      document.title = "aycarl. — AI solutions engineer";
-    };
-  }, [data]);
+  usePageMeta({
+    title: data?.post ? `${data.post.title} — aycarl.` : "Loading — aycarl.",
+    description: data?.post?.excerpt || "Read this writing on aycarl.",
+    canonicalPath: data?.post ? `/writing/${data.post.slug}` : undefined,
+  });
 
   if (isLoading) {
     return (

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -1,10 +1,10 @@
 import { Link, useParams } from "react-router-dom";
-import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Markdown } from "@/components/Markdown";
 import { fetchProjectBySlug } from "@/lib/craft";
 import { ArrowLeft, ArrowUpRight } from "lucide-react";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 const accentDot: Record<string, string> = {
   sky: "bg-sky",
@@ -22,9 +22,11 @@ const Project = () => {
     enabled: !!slug,
   });
 
-  useEffect(() => {
-    if (project) document.title = `${project.title} — aycarl.`;
-  }, [project]);
+  usePageMeta({
+    title: project ? `${project.title} — aycarl.` : "Loading — aycarl.",
+    description: project?.summary || "Read about this project on aycarl.",
+    canonicalPath: project ? `/projects/${project.slug}` : undefined,
+  });
 
   if (isLoading) {
     return (

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -3,6 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { SiteLayout } from "@/components/SiteLayout";
 import { PageHero } from "@/components/PageHero";
 import { fetchProjects } from "@/lib/craft";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { ROUTE_META } from "@/lib/seo";
 
 const accentDot: Record<string, string> = {
   sky: "bg-sky",
@@ -13,6 +15,7 @@ const accentDot: Record<string, string> = {
 };
 
 const Projects = () => {
+  usePageMeta(ROUTE_META["/projects"]);
   const { data: projects, isLoading, error } = useQuery({ queryKey: ["projects"], queryFn: fetchProjects });
 
   return (

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -5,6 +5,8 @@ import { ArrowLeft, Search as SearchIcon } from "lucide-react";
 import { SiteLayout } from "@/components/SiteLayout";
 import { searchPosts } from "@/lib/craft";
 import { Input } from "@/components/ui/input";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { ROUTE_META } from "@/lib/seo";
 
 const formatDate = (d: string) =>
   new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
@@ -38,6 +40,7 @@ const Highlight = ({ text, query }: { text: string; query: string }) => {
 };
 
 const SearchPage = () => {
+  usePageMeta(ROUTE_META["/writing/search"]);
   const [params, setParams] = useSearchParams();
   const initial = params.get("q") ?? "";
   const [input, setInput] = useState(initial);

--- a/src/pages/Tag.tsx
+++ b/src/pages/Tag.tsx
@@ -5,10 +5,16 @@ import { SiteLayout } from "@/components/SiteLayout";
 import { PostListItem } from "@/components/PostListItem";
 import { fetchPosts } from "@/lib/craft";
 import { PostListSkeleton } from "@/components/PostListSkeleton";
+import { usePageMeta } from "@/hooks/usePageMeta";
 
 const Tag = () => {
   const { tag } = useParams<{ tag: string }>();
   const decoded = tag ? decodeURIComponent(tag) : "";
+  usePageMeta({
+    title: `#${decoded} — Writing — aycarl.`,
+    description: `Posts tagged #${decoded} on aycarl.`,
+    canonicalPath: `/writing/tag/${encodeURIComponent(decoded)}`,
+  });
   const { data: posts, isLoading, error } = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
 
   const filtered = posts?.filter((p) => p.tags.some((t) => t.toLowerCase() === decoded.toLowerCase())) ?? [];

--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -6,8 +6,11 @@ import { PageHero } from "@/components/PageHero";
 import { PostListItem } from "@/components/PostListItem";
 import { fetchPosts } from "@/lib/craft";
 import { PostListSkeleton } from "@/components/PostListSkeleton";
+import { usePageMeta } from "@/hooks/usePageMeta";
+import { ROUTE_META } from "@/lib/seo";
 
 const Writing = () => {
+  usePageMeta(ROUTE_META["/writing"]);
   const { data: posts, isLoading, error } = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
   const recent = posts?.slice(0, 3) ?? [];
 

--- a/src/test/seo.test.ts
+++ b/src/test/seo.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { ROUTE_META, STATIC_ROUTES, buildSitemapXml, canonicalFor, SITE_URL } from "@/lib/seo";
+
+describe("ROUTE_META coverage", () => {
+  it("has an entry for every static route", () => {
+    for (const path of STATIC_ROUTES) {
+      expect(ROUTE_META[path], `missing ROUTE_META entry for ${path}`).toBeDefined();
+      expect(ROUTE_META[path].title.length).toBeGreaterThan(0);
+      expect(ROUTE_META[path].description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("marks /writing/search and /links as noindex", () => {
+    expect(ROUTE_META["/writing/search"]?.noindex).toBe(true);
+    expect(ROUTE_META["/links"]?.noindex).toBe(true);
+  });
+
+  it("does not list noindex routes in the sitemap's static route list", () => {
+    expect(STATIC_ROUTES).not.toContain("/links");
+    expect(STATIC_ROUTES).not.toContain("/writing/search");
+  });
+});
+
+describe("buildSitemapXml", () => {
+  it("escapes & in URLs", () => {
+    const xml = buildSitemapXml([{ loc: `${SITE_URL}/writing/foo-&-bar` }]);
+    expect(xml).toContain("foo-&amp;-bar");
+    expect(xml).not.toContain("foo-&-bar<");
+  });
+
+  it("includes lastmod only when provided", () => {
+    const xml = buildSitemapXml([{ loc: SITE_URL, lastmod: "2026-01-01" }, { loc: `${SITE_URL}/about` }]);
+    expect(xml).toContain("<lastmod>2026-01-01</lastmod>");
+    expect(xml).toContain(`<url><loc>${SITE_URL}/about</loc></url>`);
+  });
+});
+
+describe("canonicalFor", () => {
+  it("builds an absolute canonical URL", () => {
+    expect(canonicalFor("/writing/my-post")).toBe(`${SITE_URL}/writing/my-post`);
+  });
+
+  it("strips query strings, hashes, and trailing slashes", () => {
+    expect(canonicalFor("/about/?x=1#y")).toBe(`${SITE_URL}/about`);
+    expect(canonicalFor("/")).toBe(SITE_URL);
+  });
+});


### PR DESCRIPTION
## Summary

Package 2 of 3 (foundation, #54, already merged into main).

- Per-route edge functions for every static path (`/about`, `/experience`, `/links`, `/writing`, `/writing/archive`, `/writing/search`, `/writing/tag/:tag`, `/projects`) — full `ROUTE_META` table, `noindex` on `/links` and `/writing/search`
- `functions/sitemap.xml.ts` — pulls live Craft posts/projects, degrades to static-only routes if Craft is unreachable (never 500s); `robots.txt` now references it
- `src/hooks/usePageMeta` — client-side counterpart to `injectMeta`, keeps title/description/canonical in sync on SPA navigation. Replaces 4 ad-hoc `useEffect` title-setters (Post, Project, Links, NotFound) and adds title/description to 8 pages that never touched `document.title` before (Index, Writing, Archive, SearchPage, Tag, Projects, About, Experience)
- JSON-LD: `Person`/`WebSite`/`BlogPosting`/`BreadcrumbList` builders in `src/lib/seo.ts`, wired into the two Craft slug functions

### A finding worth flagging

While verifying this against `npx wrangler pages dev`, I found that Cloudflare Pages Functions routing does not reliably invoke a function for the bare `/` path when a literal `index.html` asset exists there — reproduced on both wrangler 4.93.0 and the latest 4.110.0, and consistent with a category of routing-precedence bugs already reported against `workers-sdk` (e.g. [#3406](https://github.com/cloudflare/workers-sdk/issues/3406)). Every other route I added (which has no literal matching static file — they all rely on the SPA fallback) routed through its function correctly; only the exact-match root asset was affected.

Rather than gamble on whether production behaves differently from local dev, I removed `functions/index.ts` and moved the homepage's `Person`/`WebSite` JSON-LD directly into `index.html` as static markup — same "static baseline, edge only overrides dynamic content" approach already used for the OG tags. This is a zero-risk way to sidestep the ambiguity entirely rather than ship something I can't verify.

## Test plan

- [x] `npm run build`, `npm run test` (22/22 passing, includes new `seo.test.ts`), `npm run lint` (zero new errors)
- [x] `wrangler pages dev` — verified every static route serves correct title/description/canonical/robots, `/writing/tag/:tag` works and doesn't get swallowed by `[slug].ts`
- [x] Verified `/writing/archive` and `/writing/search` are handled by their own function files, not falling through to `functions/writing/[slug].ts`'s post-lookup
- [x] `sitemap.xml` resolves correctly at the edge and includes live post/project URLs with `lastmod`
- [x] JSON-LD validated as well-formed JSON on homepage (`Person`+`WebSite`) and on a real post/project page (`BlogPosting`+`BreadcrumbList`, `BreadcrumbList` respectively)
- [ ] Google Rich Results Test / schema.org validator — needs a public preview URL

## Open items for you

- `/links` is marked `noindex` (thin QR-code destination duplicating nav) — flip if you'd rather it be indexed
- JSON-LD `Person.name` uses the `aycarl.` brand string per your earlier answer
- Google Search Console sitemap submission is a manual follow-up outside this repo

(Note: this PR was originally opened as #55, stacked on #54. Deleting #54's branch after merge auto-closed it in a state GitHub wouldn't let me reopen/retarget, so this is a fresh PR with identical content, now based directly on main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)