### PR TITLE
Add full name to About page, meta description, and JSON-LD

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       the removed functions/index.ts). Keep this in sync with
       personJsonLd()/webSiteJsonLd() in src/lib/seo.ts.
     -->
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Person","name":"aycarl.","url":"https://aycarl.com","jobTitle":"AI Solutions Engineer","sameAs":["https://github.com/aycarl","https://www.linkedin.com/in/aycarl"]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Person","name":"Carl Yao Agbenyega","alternateName":"aycarl.","url":"https://aycarl.com","jobTitle":"AI Solutions Engineer","sameAs":["https://github.com/aycarl","https://www.linkedin.com/in/aycarl"]}</script>
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"aycarl.","url":"https://aycarl.com","potentialAction":{"@type":"SearchAction","target":"https://aycarl.com/writing/search?q={search_term_string}","query-input":"required name=search_term_string"}}</script>
   </head>
   <body>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -28,6 +28,7 @@ declare class HTMLRewriter {
 
 export { SITE_URL };
 export const SITE_NAME = "aycarl.";
+export const FULL_NAME = "Carl Yao Agbenyega";
 export const DEFAULT_OG_IMAGE = `${SITE_URL}/og-default.png`;
 export const DEFAULT_OG_IMAGE_WIDTH = "1200";
 export const DEFAULT_OG_IMAGE_HEIGHT = "630";
@@ -48,7 +49,7 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/": { title: DEFAULT_TITLE, description: DEFAULT_DESCRIPTION },
   "/about": {
     title: "About — aycarl.",
-    description: "Background, approach, and how to get in touch with Carl — AI solutions engineer and full-stack developer.",
+    description: `${FULL_NAME} — AI solutions engineer and full-stack developer. Background, approach, and how to get in touch.`,
   },
   "/experience": {
     title: "Experience — aycarl.",
@@ -254,7 +255,8 @@ export function personJsonLd() {
   return {
     "@context": "https://schema.org",
     "@type": "Person",
-    name: SITE_NAME,
+    name: FULL_NAME,
+    alternateName: SITE_NAME,
     url: SITE_URL,
     jobTitle: "AI Solutions Engineer",
     sameAs: [GITHUB_URL, LINKEDIN_URL],
@@ -294,7 +296,7 @@ export function blogPostingJsonLd(post: BlogPostingInput) {
     // field), so datePublished/dateModified are always identical.
     datePublished: post.date || undefined,
     dateModified: post.date || undefined,
-    author: { "@type": "Person", name: SITE_NAME, url: SITE_URL },
+    author: { "@type": "Person", name: FULL_NAME, url: SITE_URL },
     publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
     mainEntityOfPage: { "@type": "WebPage", "@id": url },
   };

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -13,9 +13,10 @@ const About = () => {
       <section className="container py-16 md:py-24 grid grid-cols-1 md:grid-cols-12 gap-12">
         <div className="md:col-span-7">
           <p className="text-sm uppercase tracking-widest text-foreground/60 mb-4">About</p>
-          <h1 className="wordmark text-6xl md:text-8xl mb-8">
+          <h1 className="wordmark text-6xl md:text-8xl mb-3">
             Hi, I'm Carl<span className="text-yellow">.</span>
           </h1>
+          <p className="text-sm text-foreground/50 tracking-wide mb-8">Carl Yao Agbenyega</p>
           <div className="space-y-5 text-lg text-foreground/80">
             <p>
               I'm an AI solutions engineer and full-stack developer. I help teams figure out


### PR DESCRIPTION
## Summary

- JSON-LD `Person.name` is now "Carl Yao Agbenyega" (was the "aycarl." brand string), with `alternateName: "aycarl."` added — schema.org's intended pattern for a formal name + brand/nickname. `BlogPosting.author` follows suit for consistency.
- `/about`'s meta description now leads with the full name.
- `/about` shows "Carl Yao Agbenyega" as a small byline under the "Hi, I'm Carl." heading (screenshot-verified, matches the site's existing quiet-muted-text style used elsewhere).

## Test plan

- [x] `npm run build`, `npm run test` (31/31), `npm run lint` (no new errors)
- [x] Verified homepage JSON-LD in the built output: `Person.name` = full name, `alternateName` = brand
- [x] Screenshotted `/about` in a real browser — byline renders cleanly, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)